### PR TITLE
Remove unnecessary filter

### DIFF
--- a/ha5kdr-csb-getdata.php
+++ b/ha5kdr-csb-getdata.php
@@ -39,8 +39,6 @@
 			"`state` like '%$searchtok%' or " .
 			"`levelofexam` like '%$searchtok%' or " .
 			"`morse` like '%$searchtok%' or " .
-			"`licensedate` like '%$searchtok%' or " .
-			"`validity` like '%$searchtok%' or " .
 			"`chiefoperator` like '%$searchtok%') ";
 	}
 


### PR DESCRIPTION
Dátumokra történő szűrés eltávolítása. Ékezetes betűs szűrés esetén db hibát dob az oldal. Pl. Győr. Eltávolítás után működik a szűrés.